### PR TITLE
Use the Solr 'terms' query parser for enforcing parsed ACL rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,12 @@
             <email>jakob.frank@redlink.co</email>
             <organization>Redlink GmbH</organization>
         </developer>
+        <developer>
+            <id>westei</id>
+            <name>Rupert Westenthaler</name>
+            <email>rupert.westenthaler@redlink.co</email>
+            <organization>Redlink GmbH</organization>
+        </developer>
     </developers>
 
     <scm>

--- a/src/main/java/io/chatpal/solr/ext/handler/ChatpalSearchRequestHandler.java
+++ b/src/main/java/io/chatpal/solr/ext/handler/ChatpalSearchRequestHandler.java
@@ -221,32 +221,10 @@ public class ChatpalSearchRequestHandler extends SearchHandler {
     }
 
     private String buildACLFilter(SolrParams params) {
-        return buildTermsQuery(params, ChatpalParams.PARAM_ACL, ChatpalParams.FIELD_ACL);
+        return QueryHelper.buildTermsQuery(params, ChatpalParams.PARAM_ACL, ChatpalParams.FIELD_ACL);
     }
 
-    private String buildTermsQuery(SolrParams solrParams, String param, String field){
-        final String[] values = solrParams.getParams(param);
-        if (values == null || values.length < 1) {
-            return "-" + field + ":*";
-        }
-        return String.format("{!terms f=%s}", field) +
-                Arrays.stream(values)
-                        .filter(StringUtils::isNoneBlank)
-                        .collect(Collectors.joining(","));
-    }
-    
-    @SuppressWarnings("unused")
-    private String buildOrFilter(SolrParams solrParams, String param, String field) {
-        final String[] values = solrParams.getParams(param);
-        if (values == null || values.length < 1) {
-            return "-" + field + ":*";
-        }
 
-        return "{!q.op=OR}" + field + ":" +
-                Arrays.stream(values)
-                        .map(ClientUtils::escapeQueryChars)
-                        .collect(Collectors.joining(" ", "(", ")"));
-    }
 
     private interface QueryAdapter {
         void adaptQuery(ModifiableSolrParams query, SolrQueryRequest req, SolrQueryResponse rsp, DocType docType);

--- a/src/main/java/io/chatpal/solr/ext/handler/ChatpalSearchRequestHandler.java
+++ b/src/main/java/io/chatpal/solr/ext/handler/ChatpalSearchRequestHandler.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+
 package io.chatpal.solr.ext.handler;
 
 import io.chatpal.solr.ext.ChatpalParams;
@@ -21,7 +22,6 @@ import io.chatpal.solr.ext.DocType;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.index.IndexableField;
-import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.params.*;
 import org.apache.solr.common.util.NamedList;
@@ -38,7 +38,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 public class ChatpalSearchRequestHandler extends SearchHandler {
 
@@ -221,7 +220,7 @@ public class ChatpalSearchRequestHandler extends SearchHandler {
     }
 
     private String buildACLFilter(SolrParams params) {
-        return QueryHelper.buildTermsQuery(params, ChatpalParams.PARAM_ACL, ChatpalParams.FIELD_ACL);
+        return QueryHelper.buildTermsQuery(ChatpalParams.FIELD_ACL, params.getParams(ChatpalParams.PARAM_ACL));
     }
 
 

--- a/src/main/java/io/chatpal/solr/ext/handler/ChatpalSearchRequestHandler.java
+++ b/src/main/java/io/chatpal/solr/ext/handler/ChatpalSearchRequestHandler.java
@@ -216,15 +216,26 @@ public class ChatpalSearchRequestHandler extends SearchHandler {
         return ChatpalParams.FIELD_TYPE + ":" + type.getIndexVal();
     }
 
-    @SuppressWarnings("unused")
     private void appendACLFilter(ModifiableSolrParams query, SolrQueryRequest req, SolrQueryResponse rsp, DocType docType) {
         query.add(CommonParams.FQ, buildACLFilter(req.getParams()));
     }
 
     private String buildACLFilter(SolrParams params) {
-        return buildOrFilter(params, ChatpalParams.PARAM_ACL, ChatpalParams.FIELD_ACL);
+        return buildTermsQuery(params, ChatpalParams.PARAM_ACL, ChatpalParams.FIELD_ACL);
     }
 
+    private String buildTermsQuery(SolrParams solrParams, String param, String field){
+        final String[] values = solrParams.getParams(param);
+        if (values == null || values.length < 1) {
+            return "-" + field + ":*";
+        }
+        return String.format("{!terms f=%s}", field) +
+                Arrays.stream(values)
+                        .filter(StringUtils::isNoneBlank)
+                        .collect(Collectors.joining(","));
+    }
+    
+    @SuppressWarnings("unused")
     private String buildOrFilter(SolrParams solrParams, String param, String field) {
         final String[] values = solrParams.getParams(param);
         if (values == null || values.length < 1) {

--- a/src/main/java/io/chatpal/solr/ext/handler/QueryHelper.java
+++ b/src/main/java/io/chatpal/solr/ext/handler/QueryHelper.java
@@ -1,24 +1,40 @@
+/*
+ * Copyright 2018 Redlink GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package io.chatpal.solr.ext.handler;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.solr.client.solrj.util.ClientUtils;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.solr.client.solrj.util.ClientUtils;
-import org.apache.solr.common.params.SolrParams;
-
 public class QueryHelper {
-    
+
+    private QueryHelper() { }
+
     /**
      * Builds a query that requires one of the parsed terms by using the Solr terms
      * query parser
-     * @param solrParams
-     * @param param
      * @param field
+     * @param values
      * @return
      */
-    public static String buildTermsQuery(SolrParams solrParams, String param, String field){
-        final String[] values = solrParams.getParams(param);
+    public static String buildTermsQuery(String field, String[] values){
         if (values == null || values.length < 1) {
             return "-" + field + ":*";
         }
@@ -30,13 +46,11 @@ public class QueryHelper {
     /**
      * Builds a query that requires one of the parsed terms by using a normal solr
      * OR query
-     * @param solrParams
-     * @param param
      * @param field
+     * @param values
      * @return
      */
-    public static String buildOrFilter(SolrParams solrParams, String param, String field) {
-        final String[] values = solrParams.getParams(param);
+    public static String buildOrFilter(String field, String[] values) {
         if (values == null || values.length < 1) {
             return "-" + field + ":*";
         }

--- a/src/main/java/io/chatpal/solr/ext/handler/QueryHelper.java
+++ b/src/main/java/io/chatpal/solr/ext/handler/QueryHelper.java
@@ -1,0 +1,49 @@
+package io.chatpal.solr.ext.handler;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.solr.client.solrj.util.ClientUtils;
+import org.apache.solr.common.params.SolrParams;
+
+public class QueryHelper {
+    
+    /**
+     * Builds a query that requires one of the parsed terms by using the Solr terms
+     * query parser
+     * @param solrParams
+     * @param param
+     * @param field
+     * @return
+     */
+    public static String buildTermsQuery(SolrParams solrParams, String param, String field){
+        final String[] values = solrParams.getParams(param);
+        if (values == null || values.length < 1) {
+            return "-" + field + ":*";
+        }
+        return String.format("{!terms f=%s}", field) +
+                Arrays.stream(values)
+                        .filter(StringUtils::isNoneBlank)
+                        .collect(Collectors.joining(","));
+    }
+    /**
+     * Builds a query that requires one of the parsed terms by using a normal solr
+     * OR query
+     * @param solrParams
+     * @param param
+     * @param field
+     * @return
+     */
+    public static String buildOrFilter(SolrParams solrParams, String param, String field) {
+        final String[] values = solrParams.getParams(param);
+        if (values == null || values.length < 1) {
+            return "-" + field + ":*";
+        }
+
+        return "{!q.op=OR}" + field + ":" +
+                Arrays.stream(values)
+                        .map(ClientUtils::escapeQueryChars)
+                        .collect(Collectors.joining(" ", "(", ")"));
+    }
+}

--- a/src/main/java/io/chatpal/solr/ext/handler/SuggestionRequestHandler.java
+++ b/src/main/java/io/chatpal/solr/ext/handler/SuggestionRequestHandler.java
@@ -120,18 +120,7 @@ public class SuggestionRequestHandler extends SearchHandler {
     }
 
     private String buildACLFilter(SolrParams params) {
-        return buildOrFilter(params, ChatpalParams.PARAM_ACL, ChatpalParams.FIELD_ACL);
+        return QueryHelper.buildTermsQuery(params, ChatpalParams.PARAM_ACL, ChatpalParams.FIELD_ACL);
     }
 
-    private String buildOrFilter(SolrParams solrParams, String param, String field) {
-        final String[] values = solrParams.getParams(param);
-        if (values == null || values.length < 1) {
-            return "-" + field + ":*";
-        }
-
-        return "{!q.op=OR}" + field + ":" +
-                Arrays.stream(values)
-                        .map(ClientUtils::escapeQueryChars)
-                        .collect(Collectors.joining(" ", "(", ")"));
-    }
 }

--- a/src/main/java/io/chatpal/solr/ext/handler/SuggestionRequestHandler.java
+++ b/src/main/java/io/chatpal/solr/ext/handler/SuggestionRequestHandler.java
@@ -19,8 +19,6 @@ package io.chatpal.solr.ext.handler;
 
 import com.google.common.collect.ImmutableMap;
 import io.chatpal.solr.ext.ChatpalParams;
-import io.chatpal.solr.ext.DocType;
-import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.StringUtils;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.FacetParams;
@@ -45,6 +43,7 @@ public class SuggestionRequestHandler extends SearchHandler {
 
     private static final int MAX_SIZE = 10;
 
+    @Override
     public void handleRequestBody(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
 
         ModifiableSolrParams params = new ModifiableSolrParams();
@@ -120,7 +119,7 @@ public class SuggestionRequestHandler extends SearchHandler {
     }
 
     private String buildACLFilter(SolrParams params) {
-        return QueryHelper.buildTermsQuery(params, ChatpalParams.PARAM_ACL, ChatpalParams.FIELD_ACL);
+        return QueryHelper.buildTermsQuery(ChatpalParams.FIELD_ACL, params.getParams(ChatpalParams.PARAM_ACL));
     }
 
 }


### PR DESCRIPTION
This is required as the old OR clause is limited by the [maxBooleanClauses](https://lucene.apache.org/solr/guide/7_3/query-settings-in-solrconfig.html#maxbooleanclauses) and will therefore break if a user has a lot of channel subscriptions

This closes #3.