### PR TITLE
Add Support for excluding rooms and messages from search-results

### DIFF
--- a/src/main/java/io/chatpal/solr/ext/ChatpalParams.java
+++ b/src/main/java/io/chatpal/solr/ext/ChatpalParams.java
@@ -26,8 +26,13 @@ public final class ChatpalParams {
     public static final String PARAM_TYPE = "type[]";
     public static final String PARAM_START = CommonParams.START;
     public static final String PARAM_ROWS = CommonParams.ROWS;
+    
+    public static final String PARAM_EXCL_MSG = "excl.msg[]";
+    public static final String PARAM_EXCL_ROOM = "excl.room[]";
 
-    public static final String FIELD_ACL = "rid";
+    public static final String FIELD_MSG_ID = "id";
+    public static final String FIELD_ROOM_ID = "rid";
+    public static final String FIELD_ACL = FIELD_ROOM_ID;
     public static final String FIELD_TYPE = "type";
     public static final String FIELD_SUGGESTION = "suggestion";
     public static final String LANG_NONE = "none";

--- a/src/main/java/io/chatpal/solr/ext/handler/ChatpalSearchRequestHandler.java
+++ b/src/main/java/io/chatpal/solr/ext/handler/ChatpalSearchRequestHandler.java
@@ -275,9 +275,7 @@ public class ChatpalSearchRequestHandler extends SearchHandler {
         if(field == null || ArrayUtils.isEmpty(excluded)) {
             return null;
         }
-        String termsQuery = QueryHelper.buildTermsQuery(field, excluded);
-        //if the termsQuery is NOT blink we need to negate it as we do not want results with ony of the parsed terms
-        return StringUtils.isNotBlank(termsQuery) ? "-" + termsQuery : termsQuery;
+        return "-" + QueryHelper.buildTermsQuery(field, excluded);
     }
 
 

--- a/src/main/java/io/chatpal/solr/ext/handler/ChatpalSearchRequestHandler.java
+++ b/src/main/java/io/chatpal/solr/ext/handler/ChatpalSearchRequestHandler.java
@@ -275,7 +275,9 @@ public class ChatpalSearchRequestHandler extends SearchHandler {
         if(field == null || ArrayUtils.isEmpty(excluded)) {
             return null;
         }
-        return QueryHelper.buildOrFilter("-" + field, excluded);
+        String termsQuery = QueryHelper.buildTermsQuery(field, excluded);
+        //if the termsQuery is NOT blink we need to negate it as we do not want results with ony of the parsed terms
+        return StringUtils.isNotBlank(termsQuery) ? "-" + termsQuery : termsQuery;
     }
 
 

--- a/src/main/java/io/chatpal/solr/ext/handler/ChatpalSearchRequestHandler.java
+++ b/src/main/java/io/chatpal/solr/ext/handler/ChatpalSearchRequestHandler.java
@@ -256,29 +256,24 @@ public class ChatpalSearchRequestHandler extends SearchHandler {
 
     private void appendExclusionFilter(ModifiableSolrParams query, SolrQueryRequest req, DocType docType) {
         if(docType == DocType.Message || docType == DocType.Room){
-            String exclRoomFilter = buildExclusionFilter(ChatpalParams.FIELD_ROOM_ID, req.getParams());
+            String exclRoomFilter = buildExclusionFilter(ChatpalParams.FIELD_ROOM_ID, req.getParams().getParams(ChatpalParams.PARAM_EXCL_ROOM));
             if(StringUtils.isNoneBlank(exclRoomFilter)){
                 query.add(CommonParams.FQ, exclRoomFilter);
             }
         }
         if(docType == DocType.Message){
-            String exclMsgFilter = buildExclusionFilter(ChatpalParams.FIELD_MSG_ID, req.getParams());
+            String exclMsgFilter = buildExclusionFilter(ChatpalParams.FIELD_MSG_ID, req.getParams().getParams(ChatpalParams.PARAM_EXCL_MSG));
             if(StringUtils.isNoneBlank(exclMsgFilter)){
                 query.add(CommonParams.FQ, exclMsgFilter);
             }
         }
     }
 
-    private String buildExclusionFilter(String field, SolrParams params) {
-        if(field == null || params == null) {
+    private String buildExclusionFilter(String field, String...excluded) {
+        if(field == null || ArrayUtils.isEmpty(excluded)) {
             return null;
         }
-        String[] excluded = params.getParams(ChatpalParams.PARAM_EXCL_ROOM);
-        if(ArrayUtils.isNotEmpty(excluded)){
-            return QueryHelper.buildOrFilter("-" + field, excluded);
-        } else {
-            return null;
-        }
+        return QueryHelper.buildOrFilter("-" + field, excluded);
     }
 
 

--- a/src/main/java/io/chatpal/solr/ext/handler/ChatpalSearchRequestHandler.java
+++ b/src/main/java/io/chatpal/solr/ext/handler/ChatpalSearchRequestHandler.java
@@ -64,8 +64,12 @@ public class ChatpalSearchRequestHandler extends SearchHandler {
     public void handleRequestBody(SolrQueryRequest originalReq, SolrQueryResponse rsp) throws Exception {
         long start = System.currentTimeMillis();
 
-        final Loggable msgLog = queryFor(DocType.Message, originalReq, rsp, this::appendACLFilter);
-        final Loggable roomLog = queryFor(DocType.Room, originalReq, rsp, this::appendACLFilter);
+        final Loggable msgLog = queryFor(DocType.Message, originalReq, rsp,
+                this::appendACLFilter,
+                this::appendExclusionFilter);
+        final Loggable roomLog = queryFor(DocType.Room, originalReq, rsp,
+                this::appendACLFilter,
+                this::appendExclusionFilter);
         final Loggable userLog = queryFor(DocType.User, originalReq, rsp);
 
         final JsonLogMessage.QueryLog log = JsonLogMessage.queryLog()
@@ -118,9 +122,6 @@ public class ChatpalSearchRequestHandler extends SearchHandler {
                 .get(buildTypeParam(docType, ChatpalParams.PARAM_ROWS),
                         req.getParams().get(ChatpalParams.PARAM_ROWS)));
 
-        //Exclusions
-        appendExclusionFilter(query,req,docType);
-        
         // Type specific adaptions
         for (QueryAdapter adapter : queryAdapter) {
             adapter.adaptQuery(query, req, rsp, docType);
@@ -254,16 +255,17 @@ public class ChatpalSearchRequestHandler extends SearchHandler {
         return QueryHelper.buildTermsQuery(ChatpalParams.FIELD_ACL, params.getParams(ChatpalParams.PARAM_ACL));
     }
 
-    private void appendExclusionFilter(ModifiableSolrParams query, SolrQueryRequest req, DocType docType) {
+    private void appendExclusionFilter(ModifiableSolrParams query, SolrQueryRequest req, SolrQueryResponse rsp, DocType docType) {
+        final SolrParams params = req.getParams();
         if(docType == DocType.Message || docType == DocType.Room){
-            String exclRoomFilter = buildExclusionFilter(ChatpalParams.FIELD_ROOM_ID, req.getParams().getParams(ChatpalParams.PARAM_EXCL_ROOM));
-            if(StringUtils.isNoneBlank(exclRoomFilter)){
+            String exclRoomFilter = buildExclusionFilter(ChatpalParams.FIELD_ROOM_ID, params.getParams(ChatpalParams.PARAM_EXCL_ROOM));
+            if(StringUtils.isNotBlank(exclRoomFilter)){
                 query.add(CommonParams.FQ, exclRoomFilter);
             }
         }
         if(docType == DocType.Message){
-            String exclMsgFilter = buildExclusionFilter(ChatpalParams.FIELD_MSG_ID, req.getParams().getParams(ChatpalParams.PARAM_EXCL_MSG));
-            if(StringUtils.isNoneBlank(exclMsgFilter)){
+            String exclMsgFilter = buildExclusionFilter(ChatpalParams.FIELD_MSG_ID, params.getParams(ChatpalParams.PARAM_EXCL_MSG));
+            if(StringUtils.isNotBlank(exclMsgFilter)){
                 query.add(CommonParams.FQ, exclMsgFilter);
             }
         }

--- a/src/main/java/io/chatpal/solr/ext/handler/QueryHelper.java
+++ b/src/main/java/io/chatpal/solr/ext/handler/QueryHelper.java
@@ -39,10 +39,15 @@ public class QueryHelper {
         if(StringUtils.isBlank(field)){
             throw new IllegalArgumentException("The parsed field MUST NOT be NULL nor blank");
         }
+
         //NOTE: we create an empty terms filter if no values are parsed
+        if (values == null) {
+            values = new String[0];
+        }
+
         return String.format("{!terms f=%s}", field) +
-                values == null ? "" : Arrays.stream(values)
-                        .filter(StringUtils::isNoneBlank)
+                Arrays.stream(values)
+                        .filter(StringUtils::isNotBlank)
                         .collect(Collectors.joining(","));
     }
     /**
@@ -57,10 +62,11 @@ public class QueryHelper {
             return "-" + field + ":*";
         }
 
-        return "{!q.op=OR}" + 
+        return "{!q.op=OR}" +
                 //NOTE: a NULL or blank field denotes to the configured 'df'
                 (StringUtils.isBlank(field) ? "" : (field + ":")) + 
                 Arrays.stream(values)
+                        .filter(StringUtils::isNotBlank)
                         .map(ClientUtils::escapeQueryChars)
                         .collect(Collectors.joining(" ", "(", ")"));
     }

--- a/src/main/java/io/chatpal/solr/ext/handler/QueryHelper.java
+++ b/src/main/java/io/chatpal/solr/ext/handler/QueryHelper.java
@@ -30,16 +30,18 @@ public class QueryHelper {
     /**
      * Builds a query that requires one of the parsed terms by using the Solr terms
      * query parser
-     * @param field
-     * @param values
-     * @return
+     * @param field the field. MUST NOT be <code>null</code> nor blank
+     * @param values the values
+     * @return the terms filter
+     * @throws IllegalArgumentException if <code>null</code> or blank is parsed as field
      */
     public static String buildTermsQuery(String field, String[] values){
-        if (values == null || values.length < 1) {
-            return "-" + field + ":*";
+        if(StringUtils.isBlank(field)){
+            throw new IllegalArgumentException("The parsed field MUST NOT be NULL nor blank");
         }
+        //NOTE: we create an empty terms filter if no values are parsed
         return String.format("{!terms f=%s}", field) +
-                Arrays.stream(values)
+                values == null ? "" : Arrays.stream(values)
                         .filter(StringUtils::isNoneBlank)
                         .collect(Collectors.joining(","));
     }
@@ -55,7 +57,9 @@ public class QueryHelper {
             return "-" + field + ":*";
         }
 
-        return "{!q.op=OR}" + field + ":" +
+        return "{!q.op=OR}" + 
+                //NOTE: a NULL or blank field denotes to the configured 'df'
+                (StringUtils.isBlank(field) ? "" : (field + ":")) + 
                 Arrays.stream(values)
                         .map(ClientUtils::escapeQueryChars)
                         .collect(Collectors.joining(" ", "(", ")"));

--- a/src/main/java/io/chatpal/solr/ext/handler/QueryHelper.java
+++ b/src/main/java/io/chatpal/solr/ext/handler/QueryHelper.java
@@ -53,14 +53,18 @@ public class QueryHelper {
     }
     /**
      * Builds a query that requires one of the parsed terms by using a normal solr
-     * OR query
+     * OR query.
      * @param field the field-name of the or query
      * @param values the values to query for ({@code OR})
      * @return field-query-string, connected with the {@code OR} operator
      */
     public static String buildOrFilter(String field, String[] values) {
         if (values == null || values.length < 1) {
-            return "-" + field + ":*";
+            if (StringUtils.isBlank(field)) {
+                return "-[* TO *]";
+            } else {
+                return "-" + field + ":*";
+            }
         }
 
         return "{!q.op=OR}" +

--- a/src/test/java/io/chatpal/solr/ext/handler/QueryHelperTest.java
+++ b/src/test/java/io/chatpal/solr/ext/handler/QueryHelperTest.java
@@ -18,6 +18,7 @@
 package io.chatpal.solr.ext.handler;
 
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matcher;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -34,10 +35,16 @@ public class QueryHelperTest {
                 CoreMatchers.is("{!terms f=foo}x1,x3,x5,x6"));
 
         Assert.assertThat(QueryHelper.buildTermsQuery("empty", new String[0]),
-                CoreMatchers.is("-empty:*"));
+                CoreMatchers.is("{!terms f=empty}"));
         Assert.assertThat(QueryHelper.buildTermsQuery("null", null),
-                CoreMatchers.is("-null:*"));
+                CoreMatchers.is("{!terms f=null}"));
 
+        try {
+            QueryHelper.buildTermsQuery(null, new String[0]);
+            Assert.fail("IllegalArgumentException expected");
+        } catch (final Exception e) {
+            Assert.assertThat(e, CoreMatchers.instanceOf(IllegalArgumentException.class));
+        }
     }
 
     @Test
@@ -47,10 +54,18 @@ public class QueryHelperTest {
         Assert.assertThat(QueryHelper.buildOrFilter("foo", new String[]{"x1", "x\"2", "x3", null, "x5", "", "x7"}),
                 CoreMatchers.is("{!q.op=OR}foo:(x1 x\\\"2 x3 x5 x7)"));
 
+        Assert.assertThat(QueryHelper.buildOrFilter(null, new String[]{"x1", "x2", "x3", "x4"}),
+                CoreMatchers.is("{!q.op=OR}(x1 x2 x3 x4)"));
+        Assert.assertThat(QueryHelper.buildOrFilter(null, new String[]{"x1", "x\"2", "x3", null, "x5", "", "x7"}),
+                CoreMatchers.is("{!q.op=OR}(x1 x\\\"2 x3 x5 x7)"));
+
         Assert.assertThat(QueryHelper.buildOrFilter("empty", new String[0]),
                 CoreMatchers.is("-empty:*"));
         Assert.assertThat(QueryHelper.buildOrFilter("null", null),
                 CoreMatchers.is("-null:*"));
+
+        Assert.assertThat(QueryHelper.buildOrFilter(null, new String[0]), CoreMatchers.is("-[* TO *]"));
+        Assert.assertThat(QueryHelper.buildOrFilter(null, null), CoreMatchers.is("-[* TO *]"));
 
     }
 }


### PR DESCRIPTION
This adds support for two new parameters:

* `excl.msg[]` allows to exclude specific messages from the search result
* `excl.room[]` allows to include rooms/channels

Those two parameters are intended to be used for implicit queries. Where the current context of the user is used to generate search terms to search for relevant content. In such use cases one typically want to exclude messages/rooms currently viewed by the user.

Resolves #5