### PR TITLE
Add Support for Solr Queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <solr.version>7.2.1</solr.version>
         <junit.version>4.12</junit.version>
+
+        <solr.version>7.5.0</solr.version>
+
     </properties>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
+        <solr.version>7.2.1</solr.version>
         <junit.version>4.12</junit.version>
-
-        <solr.version>7.5.0</solr.version>
-
     </properties>
 
     <licenses>

--- a/src/main/java/io/chatpal/solr/ext/ChatpalParams.java
+++ b/src/main/java/io/chatpal/solr/ext/ChatpalParams.java
@@ -20,7 +20,16 @@ import org.apache.solr.common.params.CommonParams;
 
 public final class ChatpalParams {
 
+	/**
+	 * THe basic Rocket.Chat search text
+	 */
     public static final String PARAM_TEXT = "text";
+    /**
+     * Allows to parse a Query using Solr syntax. If present this takes
+     * preference over {@link #PARAM_TEXT}
+     */
+    public static final String PARAM_QUERY = "query";
+
     public static final String PARAM_LANG = "language";
     public static final String PARAM_ACL = "acl[]";
     public static final String PARAM_TYPE = "type[]";

--- a/src/main/java/io/chatpal/solr/ext/handler/ChatpalSearchRequestHandler.java
+++ b/src/main/java/io/chatpal/solr/ext/handler/ChatpalSearchRequestHandler.java
@@ -22,11 +22,9 @@ import io.chatpal.solr.ext.DocType;
 import io.chatpal.solr.ext.logging.JsonLogMessage;
 import io.chatpal.solr.ext.logging.ReportingLogger;
 
-import org.apache.calcite.avatica.proto.Common;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.index.IndexableField;
-import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.params.*;
 import org.apache.solr.common.util.NamedList;

--- a/src/main/java/io/chatpal/solr/ext/handler/ChatpalSearchRequestHandler.java
+++ b/src/main/java/io/chatpal/solr/ext/handler/ChatpalSearchRequestHandler.java
@@ -24,6 +24,7 @@ import io.chatpal.solr.ext.logging.ReportingLogger;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.index.IndexableField;
+import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.params.*;
 import org.apache.solr.common.util.NamedList;
@@ -95,8 +96,15 @@ public class ChatpalSearchRequestHandler extends SearchHandler {
         final ModifiableSolrParams query = new ModifiableSolrParams();
         final String language = req.getParams().get(ChatpalParams.PARAM_LANG, ChatpalParams.LANG_NONE);
 
-        query.set(CommonParams.Q, req.getParams().get(ChatpalParams.PARAM_TEXT));
-
+        //NOTES: 
+        // * the 'query' parameter overrides the 'text' parameter
+        // * the 'text' parameter only allows for wildcards ('*' and '?')
+        String q = req.getParams().get(ChatpalParams.PARAM_QUERY, 
+                QueryHelper.cleanTextQuery(req.getParams().get(ChatpalParams.PARAM_TEXT)));
+        if(StringUtils.isNoneBlank(q)){
+            query.set(CommonParams.Q, q);
+        } //else we do not have a valid query ...
+        
         query.set(CommonParams.SORT, req.getParams().get(CommonParams.SORT));//TODO should be type aware?
 
         // TODO: Make this configurable

--- a/src/main/java/io/chatpal/solr/ext/handler/QueryHelper.java
+++ b/src/main/java/io/chatpal/solr/ext/handler/QueryHelper.java
@@ -20,6 +20,8 @@ package io.chatpal.solr.ext.handler;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.client.solrj.util.ClientUtils;
 
+import io.chatpal.solr.ext.ChatpalParams;
+
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
@@ -62,4 +64,33 @@ public class QueryHelper {
                         .map(ClientUtils::escapeQueryChars)
                         .collect(Collectors.joining(" ", "(", ")"));
     }
+    
+    /**
+     * Escapes <a href=
+     * "https://www.google.com/?gws_rd=ssl#q=lucene+query+parser+syntax">Lucene
+     * query parser syntax</a> not allowed in the
+     * {@link ChatpalParams#PARAM_TEXT} parameter
+     */
+    public static String cleanTextQuery(String s) {
+        if (s == null) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            // These characters are part of the query syntax and NOT allowed in
+            // the 'text' parameter.
+            // So they must be escaped
+            // NOTE: Chars in the query syntax that are allowed
+            // || c == '*' || c == '?'
+            if (c == '\\' || c == '+' || c == '-' || c == '!' || c == '(' || c == ')' || c == ':' || c == '^'
+                    || c == '[' || c == ']' || c == '\"' || c == '{' || c == '}' || c == '~' || c == '|' || c == '&'
+                    || c == ';' || c == '/' || Character.isWhitespace(c)) {
+                sb.append('\\');
+            }
+            sb.append(c);
+        }
+        return sb.toString();
+    }
+
 }

--- a/src/main/java/io/chatpal/solr/ext/handler/QueryHelper.java
+++ b/src/main/java/io/chatpal/solr/ext/handler/QueryHelper.java
@@ -67,9 +67,15 @@ public class QueryHelper {
     
     /**
      * Escapes <a href=
-     * "https://www.google.com/?gws_rd=ssl#q=lucene+query+parser+syntax">Lucene
-     * query parser syntax</a> not allowed in the
-     * {@link ChatpalParams#PARAM_TEXT} parameter
+     * "https://lucene.apache.org/solr/guide/7_5/the-standard-query-parser.html">Lucene
+     * query parser syntax</a> not allowed in the {@link ChatpalParams#PARAM_TEXT} parameter
+     * 
+     * Allowed are <ul>
+     * <li> <code>*</code> for prefix/infix
+     * <li> <code>"</code> for phrase queries
+     * <li> <code>-</code> for negation and <code>+</code> for MUST
+     * <li> white spaces are also not escaped 
+     * </ul>
      */
     public static String cleanTextQuery(String s) {
         if (s == null) {
@@ -81,11 +87,14 @@ public class QueryHelper {
             // These characters are part of the query syntax and NOT allowed in
             // the 'text' parameter.
             // So they must be escaped
-            // NOTE: Chars in the query syntax that are allowed
-            // || c == '*' || c == '?'
-            if (c == '\\' || c == '+' || c == '-' || c == '!' || c == '(' || c == ')' || c == ':' || c == '^'
-                    || c == '[' || c == ']' || c == '\"' || c == '{' || c == '}' || c == '~' || c == '|' || c == '&'
-                    || c == ';' || c == '/' || Character.isWhitespace(c)) {
+            // NOTE: 
+            //   * we do allow * for prefix/infix
+            //   * we do allow " phrase queries
+            //   * we do allow - for negation and + for MUST
+            //   * we do not escape white spaces as we do want OR for multiple terms
+            if (c == '\\' || c == '!' || c == '(' || c == ')' || c == ':' || c == '^'
+                    || c == '[' || c == ']' || c == '{' || c == '}' || c == '~' || c == '|' || c == '&'
+                    || c == '?' || c == ';' || c == '/') {
                 sb.append('\\');
             }
             sb.append(c);

--- a/src/test/java/io/chatpal/solr/ext/handler/QueryHelperTest.java
+++ b/src/test/java/io/chatpal/solr/ext/handler/QueryHelperTest.java
@@ -68,4 +68,14 @@ public class QueryHelperTest {
         Assert.assertThat(QueryHelper.buildOrFilter(null, null), CoreMatchers.is("-[* TO *]"));
 
     }
+    
+    @Test
+    public void cleanTextQuery() {
+        Assert.assertThat(QueryHelper.cleanTextQuery("Test text"), CoreMatchers.is("Test text"));
+        Assert.assertThat(QueryHelper.cleanTextQuery("Test (Junit)"), CoreMatchers.is("Test \\(Junit\\)"));
+        Assert.assertThat(QueryHelper.cleanTextQuery("Test[1]"), CoreMatchers.is("Test\\[1\\]"));
+        Assert.assertThat(QueryHelper.cleanTextQuery("Test*"), CoreMatchers.is("Test*"));
+        Assert.assertThat(QueryHelper.cleanTextQuery("-Test* +Unit &fail"), CoreMatchers.is("-Test* +Unit \\&fail"));
+        Assert.assertThat(QueryHelper.cleanTextQuery("~1:3"), CoreMatchers.is("\\~1\\:3"));
+    }
 }


### PR DESCRIPTION
This introduces the `query` parameter intended to allow parsing of Solr specific queries (see #7 for details)

The `text` parameter currently used by the chatpal search response handler does use edismax to provide best full text search capabilities. With this version parsed text is query escaped excluding `*`, `+`, `-` and `"`. Also whitespaces are not escaped to have proper multi term searches.

Resolves #7 