### PR TITLE
Solr 7.7.1 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <solr.version>7.2.1</solr.version>
+        <solr.version>7.7.1</solr.version>
         <junit.version>4.12</junit.version>
     </properties>
 


### PR DESCRIPTION
Solr 7.7.1 does no longer return the unique field for documents so we need to explicitly select the field to have it available for result processing. As we do not want this field to be sent to the client it is removed from the response.

No idea why this worked with earlier Solr versions IMHO the uid value should have never been included ...